### PR TITLE
fix Call to undefined method exception

### DIFF
--- a/src/LaravelPolicySoftCache.php
+++ b/src/LaravelPolicySoftCache.php
@@ -22,12 +22,6 @@ class LaravelPolicySoftCache
         app()->make(static::class)->cache = [];
     }
 
-    /**
-     * @param  mixed  $user
-     * @param  string  $ability
-     * @param  mixed  $args
-     * @return mixed
-     */
     public function handleGateCall(mixed $user, string $ability, mixed $args): mixed
     {
         if (! is_array($args)) {
@@ -49,11 +43,6 @@ class LaravelPolicySoftCache
         return null;
     }
 
-    /**
-     * @param  object|null  $policy
-     * @param  string  $ability
-     * @return bool
-     */
     protected function shouldCache(?object $policy, string $ability): bool
     {
         if (blank($policy)) {
@@ -72,11 +61,7 @@ class LaravelPolicySoftCache
     }
 
     /**
-     * @param  Model  $user
-     * @param  object  $policy
-     * @param  string  $ability
      * @param  array<int,mixed>  $args
-     * @return mixed
      */
     protected function callPolicyMethod(Model $user, object $policy, string $ability, array $args): mixed
     {
@@ -93,11 +78,7 @@ class LaravelPolicySoftCache
     }
 
     /**
-     * @param  Model  $user
-     * @param  object  $policy
      * @param  array<int,mixed>  $args
-     * @param  string  $ability
-     * @return string
      */
     protected function getCacheKey(Model $user, object $policy, array $args, string $ability): string
     {

--- a/src/LaravelPolicySoftCache.php
+++ b/src/LaravelPolicySoftCache.php
@@ -45,18 +45,27 @@ class LaravelPolicySoftCache
 
     protected function shouldCache(?object $policy, string $ability): bool
     {
+        // when policy is not filled don't cache it
         if (blank($policy)) {
             return false;
         }
 
+        // when policy is not an object don't cache it
+        if (! is_object($policy)) {
+            return false;
+        }
+
+        // when policy doesn't have the ability don't cache it
         if (! method_exists($policy, $ability)) {
             return false;
         }
 
+        // when policy is soft cacheable cache it
         if ($policy instanceof SoftCacheable) {
             return true;
         }
 
+        // when config is set to cache all policies cache it
         return config('policy-soft-cache.cache_all_policies', false) === true;
     }
 

--- a/src/LaravelPolicySoftCache.php
+++ b/src/LaravelPolicySoftCache.php
@@ -42,7 +42,7 @@ class LaravelPolicySoftCache
 
         $policy = Gate::getPolicyFor($model);
 
-        if ($model && $this->shouldCache($policy)) {
+        if ($model && $this->shouldCache($policy, $ability)) {
             return $this->callPolicyMethod($user, $policy, $ability, $args);
         }
 
@@ -51,11 +51,24 @@ class LaravelPolicySoftCache
 
     /**
      * @param  object|null  $policy
+     * @param  string  $ability
      * @return bool
      */
-    protected function shouldCache(?object $policy): bool
+    protected function shouldCache(?object $policy, string $ability): bool
     {
-        return $policy && ($policy instanceof SoftCacheable || config('policy-soft-cache.cache_all_policies', false) === true);
+        if (blank($policy)) {
+            return false;
+        }
+
+        if (! method_exists($policy, $ability)) {
+            return false;
+        }
+
+        if ($policy instanceof SoftCacheable) {
+            return true;
+        }
+
+        return config('policy-soft-cache.cache_all_policies', false) === true;
     }
 
     /**

--- a/tests/PolicySoftCacheTest.php
+++ b/tests/PolicySoftCacheTest.php
@@ -23,6 +23,24 @@ it('caches policy calls with SoftCacheable interface', function () {
     Config::set('policy-soft-cache.cache_all_policies', true);
 });
 
+it('does not cache policy calls when ability does not exist', function () {
+    Config::set('policy-soft-cache.cache_all_policies', false);
+
+    $user = new User();
+    $testModel = new TestModel();
+    $testModel->setAttribute('id', 1);
+
+    Gate::policy(TestModel::class, PolicyWithSoftCache::class);
+
+    $user->can('foo', $testModel);
+    $user->can('foo', $testModel);
+
+    expect(PolicyWithSoftCache::$called)->toBe(0);
+
+    PolicyWithSoftCache::$called = 0;
+    Config::set('policy-soft-cache.cache_all_policies', true);
+});
+
 it('does not cache policy calls without SoftCacheable interface', function () {
     Config::set('policy-soft-cache.cache_all_policies', false);
 


### PR DESCRIPTION
This PR fixes `Call to undefined method exception` when Gate calls policy methods which don't exist.