### PR TITLE
Support non required model instance

### DIFF
--- a/src/LaravelPolicySoftCache.php
+++ b/src/LaravelPolicySoftCache.php
@@ -80,6 +80,12 @@ class LaravelPolicySoftCache
             return $this->cache[$cacheKey];
         }
 
+        // If this first argument is a string, that means they are passing a class name to
+        // the policy, so we remove it because it shouldn't be in the method as parameter.
+        if (isset($args[0]) && is_string($args[0])) {
+            array_shift($args);
+        }
+
         $result = $policy->{$ability}(...array_merge([$user], $args));
         $this->cache[$cacheKey] = $result;
 

--- a/tests/PolicySoftCacheTest.php
+++ b/tests/PolicySoftCacheTest.php
@@ -82,6 +82,18 @@ it('does not break normal gate calls', function () {
     expect(true)->toBeTrue();
 });
 
+it('does not break if the action does not require a model instance', function () {
+    $user = new User();
+    $testModel = new TestModel();
+    $testModel->setAttribute('id', 1);
+
+    Gate::policy(TestModel::class, PolicyWithoutRequiredModel::class);
+
+    $user->can('create', [TestModel::class, 1]);
+
+    expect(true)->toBeTrue();
+});
+
 class PolicyWithSoftCache implements SoftCacheable
 {
     public static int $called = 0;
@@ -102,6 +114,14 @@ class PolicyWithoutSoftCache
     {
         static::$called++;
 
+        return true;
+    }
+}
+
+class PolicyWithoutRequiredModel
+{
+    public function create(User $user, int $value): bool
+    {
         return true;
     }
 }

--- a/tests/PolicySoftCacheTest.php
+++ b/tests/PolicySoftCacheTest.php
@@ -84,8 +84,6 @@ it('does not break normal gate calls', function () {
 
 it('does not break if the action does not require a model instance', function () {
     $user = new User();
-    $testModel = new TestModel();
-    $testModel->setAttribute('id', 1);
 
     Gate::policy(TestModel::class, PolicyWithoutRequiredModel::class);
 


### PR DESCRIPTION
This solves a type error that occurs when using policies that do not require a model instance, but need additional context to be supplied to the policy method.

For example, with the policy:
```php
class PolicyWithoutRequiredModel
{
    public function create(User $user, int $value): bool
    {
        return true;
    }
}
```
We need to call it like this:
```php
auth()->user()->can('create', [MyModel::class, 1]);
```
A type error is thrown because the second parameter receives the class name instead of the desired parameter.
