### PR TITLE
Fix double quotes typo in config publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ composer require innoge/laravel-policy-soft-cache
 You can publish the config file with:
 
 ```bash
-php artisan vendor:publish --provider="Innoge\LaravelPolicySoftCache\LaravelPolicySoftCacheServiceProvider""
+php artisan vendor:publish --provider="Innoge\LaravelPolicySoftCache\LaravelPolicySoftCacheServiceProvider"
 ```
 
 This is the contents of the published config file:


### PR DESCRIPTION
In the command for publishing the config file there is a typo with duplicate quotes.

This PR fixes the error in the README file.