### PR TITLE
Bugfix: include class in cache key to prevent incorrect cached values

### DIFF
--- a/src/LaravelPolicySoftCache.php
+++ b/src/LaravelPolicySoftCache.php
@@ -97,6 +97,6 @@ class LaravelPolicySoftCache
      */
     protected function getCacheKey(Model $user, object $policy, array $args, string $ability): string
     {
-        return $user->{$user->getKeyName()}.'_'.hash_hmac('sha512', (string) json_encode($args), config('app.key')).'_'.$ability.'_'.$policy::class;
+        return get_class($user).'_'.$user->{$user->getKeyName()}.'_'.hash_hmac('sha512', (string) json_encode($args), config('app.key')).'_'.$ability.'_'.$policy::class;
     }
 }


### PR DESCRIPTION
This is a nice and useful library, unfortunately I discovered it does not always cache the correct value in my specific use case. 

In this use case I have different user classes all implementing the Authorizable contract, and policy logic that depends on the user class. As the library does not take the class into account, this can lead to caching of incorrect values, if the models have the same key.

See the added test for an example.

The fix I implemented here is to include the user model class name in the cache key, so it works in all cases.
