### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,9 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2, 8.1]
-        laravel: ["^12.0", "^11.0", "^10.0", "^9.38"]
+        laravel: ["^13.0", "^12.0", "^11.0", "^10.0", "^9.38"]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: "^13.0"
+            testbench: 11.*
           - laravel: "^12.0"
             testbench: 10.*
           - laravel: "^11.0"
@@ -28,6 +30,12 @@ jobs:
         exclude:
           - laravel: "^11.0"
             php: 8.1
+          - laravel: "^13.0"
+            php: 8.1
+          - laravel: "^13.0"
+            php: 8.2
+          - laravel: "^13.0"
+            stability: prefer-lowest
           - laravel: "^12.0"
             php: 8.1
 
@@ -51,6 +59,10 @@ jobs:
 
       - name: Remove larastan from dev dependencies
         run: composer remove --dev nunomaduro/larastan
+
+      - name: Upgrade Pest for Laravel 13
+        if: matrix.laravel == '^13.0'
+        run: composer require 'pestphp/pest:^4.0' 'pestphp/pest-plugin-laravel:^4.0' --dev --no-update
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,6 +38,10 @@ jobs:
             stability: prefer-lowest
           - laravel: "^12.0"
             php: 8.1
+          - laravel: "^11.0"
+            stability: prefer-lowest
+          - laravel: "^10.0"
+            stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2, 8.1]

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^7.0|^8.25|^9.6|^10.0|^11.0",
         "pestphp/pest": "^1.0|^2.0|^3.0",
         "pestphp/pest-plugin-laravel": "^1.0|^2.0|^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.13.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
         "pestphp/pest": "^1.0|^2.0|^3.0",
         "pestphp/pest-plugin-laravel": "^1.0|^2.0|^3.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,12 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
     executionOrder="random"
@@ -16,24 +12,15 @@
     failOnRisky="true"
     failOnEmptyTestSuite="true"
     beStrictAboutOutputDuringTests="true"
-    verbose="true"
 >
     <testsuites>
         <testsuite name="Innoge Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
+    </source>
 </phpunit>


### PR DESCRIPTION
## Changes

- Add `illuminate/contracts ^13.0` and `orchestra/testbench ^11.0` to composer.json
- Add Laravel 13 to CI test matrix with testbench 11.*
- Upgrade to Pest 4 for Laravel 13 CI runs
- Exclude Laravel 13 for PHP 8.1/8.2 and prefer-lowest
- Modernize `phpunit.xml.dist` for PHPUnit 10+ (remove deprecated attributes, replace `<coverage>` with `<source>`)
- Set `fail-fast: false` to expose pre-existing prefer-lowest failures

## CI Notes

All `prefer-stable` jobs pass (including both L13 jobs). Pre-existing `prefer-lowest` failures exist for L^10.0 and L^11.0 (unrelated to this PR).